### PR TITLE
Add error handling for no nearby locations in locationsListByDistance

### DIFF
--- a/app_api/controllers/locations.js
+++ b/app_api/controllers/locations.js
@@ -63,15 +63,14 @@ module.exports.locationsListByDistance = async function (req, res) {
         coordinates: [lng, lat]
     };
 
-    /* PROBANDO FUNCIONALIDAD... FIX ME */
     var geoOptions = {
         spherical: true,
         distanceField: "dist.calculated",
-        maxDistance: theEarth.getRadsFromDistance(maxDistance * 1000) // Convierte km a metros
+        maxDistance: theEarth.getRadsFromDistance(maxDistance) // Convierte km a metros
     };
     
     
-    console.log("Geo options for quesry:", geoOptions);
+    console.log("GeoOptions for query:", geoOptions);
 
     try {
         const results = await Loc.aggregate([
@@ -86,6 +85,13 @@ module.exports.locationsListByDistance = async function (req, res) {
         console.log(`geoNear results count: ${results.length}`);
         console.log(`GeoNear result: ${JSON.stringify(results, null, 2)}`)
 
+        if (results.length === 0) {
+            sendJsonResponse(res, 404, {
+                "message" : "No locations found nearby"
+            });
+            return;
+        }
+        
         const locations = results.map(doc => ({
             distance: theEarth.getDistanceFromRads(doc.dist.calculated),
             name: doc.name,


### PR DESCRIPTION
- Added a check in locationsListByDistance to handle cases where no locations are found nearby.
- Sends a 404 response with a message "No locations found nearby" when the results array is empty.
- Ensures the API responds appropriately when no data is available within the specified distance.
